### PR TITLE
Mejora del hero y primera vista del dashboard

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -440,7 +440,14 @@ code {
 }
 
 @media (max-width: 920px) {
-  .header-layout,
+  .header-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-highlight {
+    max-width: 420px;
+  }
+
   .toolbar,
   .summary-grid,
   .repo-grid {
@@ -450,15 +457,11 @@ code {
   .field-search {
     grid-column: 1 / -1;
   }
-
-  .profile-link {
-    justify-self: start;
-  }
 }
 
 @media (max-width: 640px) {
   .site-header {
-    padding-top: 42px;
+    padding-top: 38px;
   }
 
   .header-layout,
@@ -466,6 +469,23 @@ code {
   .summary-grid,
   .repo-grid {
     grid-template-columns: 1fr;
+  }
+
+  h1 {
+    font-size: clamp(2.25rem, 13vw, 3.3rem);
+  }
+
+  .lead {
+    font-size: 1rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+  }
+
+  .hero-actions .button,
+  .hero-actions .profile-link {
+    width: 100%;
   }
 
   .toolbar {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -39,88 +39,168 @@ a {
 }
 
 .site-header {
-  padding: 64px 0 32px;
+  padding: 56px 0 24px;
 }
 
 .header-layout {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 24px;
-  align-items: start;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 340px);
+  gap: 40px;
+  align-items: center;
+}
+
+.hero-copy {
+  max-width: 820px;
 }
 
 .eyebrow {
-  margin: 0 0 12px;
-  color: var(--primary);
+  display: inline-flex;
+  align-items: center;
+  min-height: 28px;
+  margin: 0 0 16px;
+  padding: 0 12px;
+  border-radius: 999px;
+  color: var(--primary-dark);
+  background: rgba(37, 99, 235, 0.1);
   font-weight: 800;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
-  font-size: 0.8rem;
+  font-size: 0.74rem;
 }
 
 h1 {
   margin: 0;
-  max-width: 820px;
-  font-size: clamp(2.2rem, 6vw, 4.6rem);
-  line-height: 0.95;
-  letter-spacing: -0.06em;
+  max-width: 860px;
+  font-size: clamp(2.35rem, 5vw, 4.15rem);
+  line-height: 1;
+  letter-spacing: -0.055em;
 }
 
 .lead {
-  max-width: 720px;
-  margin: 24px 0 0;
+  max-width: 700px;
+  margin: 22px 0 0;
   color: var(--muted);
-  font-size: 1.15rem;
-  line-height: 1.7;
+  font-size: 1.12rem;
+  line-height: 1.65;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.hero-primary {
+  min-height: 46px;
+  padding-inline: 20px;
 }
 
 .profile-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 44px;
+  min-height: 46px;
   padding: 0 18px;
+  border: 1px solid var(--border);
   border-radius: 999px;
-  background: var(--text);
-  color: white;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--text);
   text-decoration: none;
-  font-weight: 700;
+  font-weight: 800;
   white-space: nowrap;
-  transition: transform 160ms ease, background 160ms ease;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.05);
+  transition: transform 160ms ease, border-color 160ms ease, color 160ms ease;
 }
 
 .profile-link:hover {
   transform: translateY(-1px);
-  background: var(--primary);
+  border-color: rgba(37, 99, 235, 0.45);
+  color: var(--primary);
+}
+
+.hero-highlight {
+  position: relative;
+  overflow: hidden;
+  padding: 28px;
+  border: 1px solid rgba(37, 99, 235, 0.16);
+  border-radius: calc(var(--radius) + 6px);
+  background:
+    linear-gradient(145deg, rgba(255, 255, 255, 0.92), rgba(238, 242, 247, 0.82)),
+    radial-gradient(circle at top right, rgba(37, 99, 235, 0.18), transparent 16rem);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(16px);
+}
+
+.hero-highlight::before {
+  content: "";
+  position: absolute;
+  inset: auto -40px -70px auto;
+  width: 160px;
+  height: 160px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+}
+
+.hero-highlight-label {
+  display: block;
+  position: relative;
+  color: var(--primary-dark);
+  font-size: 0.8rem;
+  font-weight: 900;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-highlight strong {
+  display: block;
+  position: relative;
+  margin-top: 12px;
+  font-size: clamp(3rem, 6vw, 4.6rem);
+  line-height: 0.95;
+  letter-spacing: -0.07em;
+}
+
+.hero-highlight p {
+  position: relative;
+  max-width: 230px;
+  margin: 14px 0 0;
+  color: var(--muted);
+  line-height: 1.5;
 }
 
 .summary-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 16px;
-  margin: 20px 0 28px;
+  gap: 14px;
+  margin: 16px 0 22px;
 }
 
 .summary-card {
-  background: rgba(255, 255, 255, 0.82);
+  background: rgba(255, 255, 255, 0.72);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  padding: 20px;
-  box-shadow: var(--shadow);
+  padding: 17px 18px;
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.055);
   backdrop-filter: blur(12px);
+}
+
+.summary-card-featured {
+  border-color: rgba(37, 99, 235, 0.28);
+  background: rgba(239, 246, 255, 0.74);
 }
 
 .summary-label {
   display: block;
   color: var(--muted);
-  font-size: 0.9rem;
-  margin-bottom: 10px;
+  font-size: 0.84rem;
+  margin-bottom: 8px;
 }
 
 .summary-card strong {
   display: block;
-  font-size: 1.8rem;
-  letter-spacing: -0.04em;
+  font-size: 1.55rem;
+  letter-spacing: -0.045em;
 }
 
 .toolbar {
@@ -130,21 +210,21 @@ h1 {
   display: grid;
   grid-template-columns: minmax(220px, 1fr) repeat(3, minmax(150px, 190px));
   gap: 12px;
-  padding: 14px;
+  padding: 12px;
   background: rgba(255, 255, 255, 0.86);
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  box-shadow: var(--shadow);
+  box-shadow: 0 14px 32px rgba(15, 23, 42, 0.07);
   backdrop-filter: blur(16px);
 }
 
 .field {
   display: grid;
-  gap: 7px;
+  gap: 6px;
 }
 
 .field label {
-  font-size: 0.78rem;
+  font-size: 0.72rem;
   color: var(--muted);
   font-weight: 800;
   text-transform: uppercase;
@@ -154,7 +234,7 @@ h1 {
 input,
 select {
   width: 100%;
-  min-height: 44px;
+  min-height: 42px;
   border: 1px solid var(--border);
   border-radius: var(--radius-sm);
   padding: 0 13px;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9,6 +9,7 @@ const state = {
 const elements = {
   totalRepos: document.querySelector("#totalRepos"),
   withWeb: document.querySelector("#withWeb"),
+  heroWithWeb: document.querySelector("#heroWithWeb"),
   withoutWeb: document.querySelector("#withoutWeb"),
   latestUpdate: document.querySelector("#latestUpdate"),
   searchInput: document.querySelector("#searchInput"),
@@ -164,12 +165,17 @@ function updateSummary(repos) {
 
   elements.totalRepos.textContent = total;
   elements.withWeb.textContent = withWeb;
+
+  if (elements.heroWithWeb) {
+    elements.heroWithWeb.textContent = withWeb;
+  }
+
   elements.withoutWeb.textContent = withoutWeb;
   elements.latestUpdate.textContent = latest ? formatDate(latest) : "-";
 }
 
 function updateResultsCount(visible, total) {
-  elements.resultsCount.textContent = `${visible} de ${total} repositorios visibles`;
+  elements.resultsCount.textContent = `${visible} de ${total} proyectos visibles`;
 }
 
 function renderRepos(repos) {
@@ -201,7 +207,7 @@ function createRepoCard(repo) {
         </a>
       </h3>
       <span class="badge ${publicWeb ? "badge-web" : "badge-no-web"}">
-        ${publicWeb ? "Con web" : "Sin web"}
+        ${publicWeb ? "Demo pública" : "Repositorio"}
       </span>
     </div>
 
@@ -222,12 +228,12 @@ function createRepoCard(repo) {
 
     <div class="card-actions">
       <a class="button button-secondary" href="${escapeAttribute(repo.html_url)}" target="_blank" rel="noopener noreferrer">
-        Repositorio
+        Ver repo
       </a>
-
+      
       ${publicWeb ? `
         <a class="button button-primary" href="${escapeAttribute(repo.homepage)}" target="_blank" rel="noopener noreferrer">
-          Ver web
+          Abrir demo
         </a>
       ` : ""}
     </div>

--- a/index.html
+++ b/index.html
@@ -11,42 +11,56 @@
 <body>
   <header class="site-header">
     <div class="container header-layout">
-      <div>
-        <p class="eyebrow">GitHub Projects Dashboard</p>
-        <h1>Mis proyectos públicos en GitHub</h1>
+      <div class="hero-copy">
+        <p class="eyebrow">Portfolio técnico</p>
+  
+        <h1>Explora mis proyectos, demos y experimentos públicos</h1>
+  
         <p class="lead">
-          Un índice visual para explorar repositorios, demos públicas y proyectos en desarrollo desde un solo lugar.
+          Un mapa visual de repositorios, herramientas web, pruebas de frontend y proyectos en desarrollo desde un solo lugar.
         </p>
+  
+        <div class="hero-actions">
+          <a class="button button-primary hero-primary" href="#repoGrid">
+            Explorar proyectos
+          </a>
+  
+          <a class="profile-link" href="https://github.com/sidval" target="_blank" rel="noopener noreferrer">
+            Ver GitHub
+          </a>
+        </div>
       </div>
-
-      <a class="profile-link" href="https://github.com/sidval" target="_blank" rel="noopener noreferrer">
-        Ver perfil en GitHub
-      </a>
+  
+      <aside class="hero-highlight" aria-label="Resumen destacado">
+        <span class="hero-highlight-label">Demos públicas</span>
+        <strong id="heroWithWeb">0</strong>
+        <p>proyectos disponibles para abrir y probar</p>
+      </aside>
     </div>
   </header>
 
   <main class="container">
-    <section class="summary-grid" aria-label="Resumen de repositorios">
-      <article class="summary-card">
-        <span class="summary-label">Repositorios</span>
-        <strong id="totalRepos">0</strong>
-      </article>
-
-      <article class="summary-card">
-        <span class="summary-label">Con web pública</span>
-        <strong id="withWeb">0</strong>
-      </article>
-
-      <article class="summary-card">
-        <span class="summary-label">Sin web pública</span>
-        <strong id="withoutWeb">0</strong>
-      </article>
-
-      <article class="summary-card">
-        <span class="summary-label">Última actualización</span>
-        <strong id="latestUpdate">-</strong>
-      </article>
-    </section>
+  <section class="summary-grid" aria-label="Resumen de repositorios">
+    <article class="summary-card">
+    <span class="summary-label">Total</span>
+    <strong id="totalRepos">0</strong>
+    </article>
+    
+    <article class="summary-card summary-card-featured">
+    <span class="summary-label">Demos públicas</span>
+    <strong id="withWeb">0</strong>
+    </article>
+    
+    <article class="summary-card">
+    <span class="summary-label">En repositorio</span>
+    <strong id="withoutWeb">0</strong>
+    </article>
+    
+    <article class="summary-card">
+    <span class="summary-label">Actualizado</span>
+    <strong id="latestUpdate">-</strong>
+    </article>
+  </section>
 
     <section class="toolbar" aria-label="Controles de búsqueda y filtrado">
       <div class="field field-search">


### PR DESCRIPTION
## Resumen de cambios

Se mejoró la primera sección visible del dashboard para que funcione más como un portfolio técnico y menos como un panel administrativo.

### Cambios principales

- Se actualizó el hero principal con un mensaje más orientado a exploración de proyectos, demos y experimentos públicos.
- Se reemplazó el eyebrow “GitHub Projects Dashboard” por “Portfolio técnico” para mantener un tono más claro y alineado con el resto de la página en español.
- Se agregó una acción principal para “Explorar proyectos” y se dejó el enlace a GitHub como acción secundaria.
- Se incorporó un bloque destacado en el hero para mostrar la cantidad de demos públicas disponibles.
- Se ajustó la sección de métricas para que sea más compacta y menos dominante visualmente.
- Se cambió el copy de “Sin web pública” por una alternativa más neutral: “En repositorio”.
- Se refinó la toolbar de búsqueda y filtros para reducir su peso visual en el primer pantallazo.
- Se actualizaron algunos textos de badges y botones:
  - “Con web” pasó a “Demo pública”.
  - “Sin web” pasó a “Repositorio”.
  - “Ver web” pasó a “Abrir demo”.
  - “Repositorio” pasó a “Ver repo”.
- Se sincronizó desde JS el nuevo contador destacado del hero con el total de proyectos que tienen web/demo pública.

### Objetivo

El objetivo fue mejorar la primera impresión de la página, priorizando el valor para el visitante: descubrir proyectos y abrir demos públicas rápidamente.

Antes, la primera vista se percibía más como un dashboard de repositorios. Con estos cambios, la página comunica mejor que es un portfolio visual de proyectos, manteniendo la funcionalidad de búsqueda, filtros y métricas.